### PR TITLE
Added the ability to logout and re-login without restarting the app.

### DIFF
--- a/identity.js
+++ b/identity.js
@@ -132,7 +132,7 @@ exports.removeCachedAuthToken = function(details, callback) {
     }
 
     // Invalidate the token natively.
-    exec(callback, null, 'ChromeIdentity', 'removeCachedAuthToken', [details.token]);
+    exec(callback, null, 'ChromeIdentity', 'removeCachedAuthToken', [details.token, details.signOut]);
 };
 
 exports.revokeAuthToken = function(details, callback) {
@@ -148,7 +148,7 @@ exports.revokeAuthToken = function(details, callback) {
                     console.log('Could not revoke token; status ' + xhr.status + '.');
                     callbackWithError('Failed to revoke token. Got HTTP response ' + xhr.status, callback);
                 } else {
-                    exports.removeCachedAuthToken({ token: details.token }, callback);
+                    exports.removeCachedAuthToken({ token: details.token, signOut: true }, callback);
                 }
             }
         };

--- a/src/android/ChromeIdentity.java
+++ b/src/android/ChromeIdentity.java
@@ -56,6 +56,7 @@ public class ChromeIdentity extends CordovaPlugin {
         CallbackContext callbackContext;
         String scopesString;
         boolean interactive = true;
+        boolean signOut = true;
         String accountHint;
         String token;
 
@@ -76,7 +77,7 @@ public class ChromeIdentity extends CordovaPlugin {
                     if ("getAuthToken".equals(action)) {
                         getAuthToken(interactive, scopesString, accountHint, callbackContext);
                     } else if ("removeCachedAuthToken".equals(action)) {
-                        removeCachedAuthToken(token, callbackContext);
+                        removeCachedAuthToken(token, signOut, callbackContext);
                     } else if ("getAccounts".equals(action)) {
                         getAccounts(callbackContext);
                     }
@@ -101,6 +102,7 @@ public class ChromeIdentity extends CordovaPlugin {
             callDetails.accountHint = args.isNull(3) ? null : args.getString(3);
         } else if ("removeCachedAuthToken".equals(action)) {
             callDetails.token = args.getString(0);
+            callDetails.signOut = args.getBoolean(1);
         } else if ("getAccounts".equals(action)) {
             // No args.
         } else {
@@ -276,9 +278,11 @@ public class ChromeIdentity extends CordovaPlugin {
         return jsonObject;
     }
 
-    private void removeCachedAuthToken(String token, CallbackContext callbackContext) {
-        try {
+    private void removeCachedAuthToken(String token, boolean signOut, CallbackContext callbackContext) {
+        if (signOut) {
             cachedAccountName = null;
+        }
+        try {
             Context context = cordova.getActivity();
             GoogleAuthUtil.clearToken(context, token);
             callbackContext.success();

--- a/src/android/ChromeIdentity.java
+++ b/src/android/ChromeIdentity.java
@@ -278,6 +278,7 @@ public class ChromeIdentity extends CordovaPlugin {
 
     private void removeCachedAuthToken(String token, CallbackContext callbackContext) {
         try {
+            cachedAccountName = null;
             Context context = cordova.getActivity();
             GoogleAuthUtil.clearToken(context, token);
             callbackContext.success();

--- a/src/android/ChromeIdentity.java
+++ b/src/android/ChromeIdentity.java
@@ -56,7 +56,7 @@ public class ChromeIdentity extends CordovaPlugin {
         CallbackContext callbackContext;
         String scopesString;
         boolean interactive = true;
-        boolean signOut = true;
+        boolean signOut = false;
         String accountHint;
         String token;
 

--- a/src/ios/ChromeIdentity.m
+++ b/src/ios/ChromeIdentity.m
@@ -75,6 +75,7 @@ static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelect
     if ([[authentication accessToken] isEqualToString:token]) {
         [authentication setAccessToken:nil];
         [authentication authorizeRequest:nil completionHandler:nil];
+        [[GPPSignIn sharedInstance] signOut];
     }
 
     // Call the callback.

--- a/src/ios/ChromeIdentity.m
+++ b/src/ios/ChromeIdentity.m
@@ -69,12 +69,16 @@ static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelect
 - (void)removeCachedAuthToken:(CDVInvokedUrlCommand*)command
 {
     NSString *token = [command argumentAtIndex:0];
+    BOOL signOut = [[command argumentAtIndex:1] boolValue];
     GTMOAuth2Authentication *authentication = [[GPPSignIn sharedInstance] authentication];
 
     // If the token to revoke is the same as the one we have cached, trigger a refresh.
     if ([[authentication accessToken] isEqualToString:token]) {
         [authentication setAccessToken:nil];
         [authentication authorizeRequest:nil completionHandler:nil];
+    }
+
+    if (signOut) {
         [[GPPSignIn sharedInstance] signOut];
     }
 


### PR DESCRIPTION
When attempting to logout from an app using this plugin there were issues with both iOS and Android on a single page app.

#### Android
After logging out your were unable to log in second time with a different account.  This was due to the `cachedAccountName` not being reset when removing the cachedAuth token.

#### iOS
Revoking the auth token via `removeCachedAuthToken` did not completely remove the link to the previous user.  Calling the GPPSignIn `disconnect` was not an option as the token was revoked in the identity.js file.  With the `signOut` method this is resolved and the user can logout/login without full app restart.