### PR TITLE
Add a dependency on play-services-auth.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,7 @@
 
   <platform name="android">
     <framework src="com.google.android.gms:play-services-identity:+" />
+    <framework src="com.google.android.gms:play-services-auth:+" />
 
     <source-file src="src/android/ChromeIdentity.java" target-dir="src/org/chromium" />
 


### PR DESCRIPTION
This is required to fix a compile error with Play Services v9.0+.
See the release notes for more information:
https://developers.google.com/android/guides/releases#may_2016_-_v90